### PR TITLE
devcontainerへclaudecode用の設定追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,10 +2,15 @@
   "name": "Next.js Dev Container",
   "dockerComposeFile": "../docker-compose.yml",
   "service": "web",
-  "workspaceFolder": "/app",
+  "workspaceFolder": "/src",
 
   // コンテナ作成後に実行するコマンド
   "postCreateCommand": "npm install",
+
+  // ホストの Claude 設定をマウント
+  "mounts": [
+    "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind,consistency=cached"
+  ],
 
   // VS Code設定
   "customizations": {

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+core

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
 # ベースイメージ（Debian系 - devcontainer features対応）
 FROM node:22-slim
 
+# Claude Code CLIをグローバルにインストール（rootユーザーで実行）
+RUN npm install -g @anthropic-ai/claude-code
+
 # 作業ディレクトリを設定
-WORKDIR /app
+WORKDIR /src
 
-# package.json と package-lock.json をコピー
-COPY package*.json ./
+# /src ディレクトリの所有者を node ユーザーに変更
+RUN chown -R node:node /src
 
-# 依存関係をインストール
-RUN npm ci
-
-# アプリケーションのソースコードをコピー
-COPY . .
+# nodeユーザーに切り替え
+USER node
 
 # Next.jsの開発サーバーのポートを公開
 EXPOSE 3000
 
-# 開発サーバーを起動
-CMD ["npm", "run", "dev"]
+# DevContainer用: デフォルトではコマンドを実行しない
+CMD ["sleep", "infinity"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,19 +3,18 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    image: soundlens-web
+    container_name: soundlens-web
     ports:
       - "3000:3000"
     volumes:
       # ソースコードをマウント（ホットリロード用）
-      - .:/app
-      # node_modulesは除外（コンテナ内のものを使用）
-      - /app/node_modules
-      # Next.jsのキャッシュディレクトリも除外
-      - /app/.next
+      - .:/src
     environment:
       - NODE_ENV=development
       # ホットリロードのために必要
       - WATCHPACK_POLLING=true
-    command: npm run dev
+    # DevContainer用: コンテナを起動したままにする
+    command: sleep infinity
     stdin_open: true
     tty: true


### PR DESCRIPTION
## 概要
<!-- PRの背景・目的・概要 -->
- DevContainerでclaude codeが正常に起動できること

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
-

## やったこと
<!-- このPRで何をしたのか -->
- Dockerfile, docker-compose.yml, devcontainer.jsonの修正

## やらないこと
<!-- このPRでやらないことは何か -->
- 特になし

## 動作確認
<!-- どのように動作確認を行なったか -->
- コンテナ内で claude コマンドが使える
- localhost:3000でNext.jsが動く（npm run dev 実行後）

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
-
