### PR TITLE
【feature/7】コンテナ名の設定とdevcontainerからclaudeの削除

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,16 +4,17 @@
   "service": "web",
   "workspaceFolder": "/src",
 
+  // コンテナ起動前に実行するコマンド（既存コンテナのクリーンアップ）
+  "initializeCommand": "docker compose -f ${localWorkspaceFolder}/docker-compose.yml down --remove-orphans 2>/dev/null || true",
+
   // コンテナ作成後に実行するコマンド
   "postCreateCommand": "npm install",
 
   // コンテナ開始後に実行するコマンド（worktree用のgit設定）
   "postStartCommand": "bash -c 'if [ -f .git ]; then sed -i \"s|gitdir: .*/\\.git/worktrees/|gitdir: /parent-git/worktrees/|\" .git; fi'",
 
-  // ホストの Claude 設定をマウント
+  // 親gitディレクトリをマウント（worktree対応）
   "mounts": [
-    "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind,consistency=cached",
-    // 親gitディレクトリをマウント（worktree対応）
     "source=${localWorkspaceFolder}/../soundlens-web/.git,target=/parent-git,type=bind,consistency=cached,readonly"
   ],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
       context: .
       dockerfile: Dockerfile
     image: soundlens-web
-    container_name: soundlens-web
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
## 概要
<!-- PRの背景・目的・概要 -->
- 毎回devcontainerを立ち上げるときにコンテナの削除をするのが面倒なので、立ち上げ時に削除するようにした
- devcontainerでclaudeを使わないのでコマンドの削除


## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #7 

## やったこと
<!-- このPRで何をしたのか -->
- devcontainerの立ち上げ時にコンテナを削除する
- devcontainerの立ち上げ時のコンテナ名を自動で決定する
- devcontainerでclaudeを使わないのでコマンドの削除

## やらないこと
<!-- このPRでやらないことは何か -->
- なし

## 動作確認
<!-- どのように動作確認を行なったか -->
- npm run devの実行

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
- なし
